### PR TITLE
When the current view, for example is tableview,when you touch the table...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+#
+#Pods/

--- a/CDSideBar/CDSideBarController/CDSideBarController.h
+++ b/CDSideBar/CDSideBarController/CDSideBarController.h
@@ -26,7 +26,7 @@
 @property (nonatomic, retain) UIColor *menuColor;
 @property (nonatomic) BOOL isOpen;
 
-@property (nonatomic, retain) id<CDSideBarControllerDelegate> delegate;
+@property (nonatomic, weak) id<CDSideBarControllerDelegate> delegate;
 
 - (CDSideBarController*)initWithImages:(NSArray*)buttonList;
 - (void)insertMenuButtonOnView:(UIView*)view atPosition:(CGPoint)position;

--- a/CDSideBar/CDSideBarController/CDSideBarController.m
+++ b/CDSideBar/CDSideBarController/CDSideBarController.m
@@ -47,6 +47,7 @@
     [view addSubview:_menuButton];
     
     UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissMenu)];
+    singleTap.cancelsTouchesInView = NO;
     [view addGestureRecognizer:singleTap];
     
     for (UIButton *button in _buttonList)


### PR DESCRIPTION
1.When the current view, for example is tableview,when you touch the tableview cell,it won't  run - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath.So there should be singleTap.cancelsTouchesInView = NO;
2.apple document suggest id<protocol> object to be (weak)
3.add .gitignore
